### PR TITLE
[2500708] fix : 기술일치 배경색 추가

### DIFF
--- a/src/components/PostCard/Label.tsx
+++ b/src/components/PostCard/Label.tsx
@@ -21,6 +21,7 @@ export default function Label({ type, children }: LabelProps) {
       case "포지션 일치":
         return "bg-positionMatch";
       case "기술 일치":
+        return "bg-main"
       case "기술 부분 일치":
         return "bg-skillMatch";
       case "해당 없음":


### PR DESCRIPTION
<!--
머지 제목은 항상 다음과 같은 규칙을 지킨다.
[날짜] 해당 Merge와 관련된 큰 제목
ex) [240806] 학습한 강의 수 저장 기능
머지 내용은 아래 템플릿을 복사해서 사용한다.
-->

### PR 타입

* [x] 버그 수정


### 변경 사항

* 기술 일치 배경색 추가

### 전달 사항

브랜치 문제로 재커밋
